### PR TITLE
issue 5: update PromoteTraits.h with COMPLEX_SPECIALIZE flag

### DIFF
--- a/src/util/Estimate.h
+++ b/src/util/Estimate.h
@@ -11,8 +11,6 @@
 #ifndef __Estimate_h
 #define __Estimate_h
 
-#include <config.h>
-
 #include "PromoteTraits.h"
 #include "Traits.h"
 
@@ -142,7 +140,7 @@ class Estimate
   friend const Estimate operator - (Estimate a)
   { return Estimate (-a.val, a.var); }
 
-#ifndef HAVE_COMPLEX_TEMPLATES
+#if COMPLEX_SPECIALIZE
   friend const std::complex<Estimate> operator * (const std::complex<Estimate>& a, const std::complex<Estimate>& b)
   {
     return std::complex<Estimate> (

--- a/src/util/generate_PromoteTraits.C
+++ b/src/util/generate_PromoteTraits.C
@@ -68,6 +68,10 @@ int main (int argc, char** argv)
   out << "#define PROMOTE_TRAITS_SPECIALIZE 1\n" << endl;
 #endif
 
+#if !defined(HAVE_COMPLEX_TEMPLATES)
+  out << "#define COMPLEX_SPECIALIZE 1\n" << endl;
+#endif
+
   out << "#endif // !__epsic_PromoteTraits_h\n" << endl;
 
   out.close ();
@@ -75,4 +79,3 @@ int main (int argc, char** argv)
   return 0;
 
 }
-


### PR DESCRIPTION
Instead of #include<config.h> in Estimate.h, update PromoteTraits.h with the required flag.

Resolves [issue 5](https://github.com/straten/epsic/issues/5)