### PR TITLE
Test std::norm

### DIFF
--- a/src/config/complex_templates.m4
+++ b/src/config/complex_templates.m4
@@ -39,7 +39,7 @@ template<typename T> class X {
 std::complex< X<double> > a, b, c;
 c = a * b;
 // Test if complex norm works
-c = std::norm(c);
+X<double> d = std::norm(c);
 ],
  ac_cv_cxx_complex_templates=yes,
  ac_cv_cxx_complex_templates=no)

--- a/src/config/complex_templates.m4
+++ b/src/config/complex_templates.m4
@@ -38,6 +38,8 @@ template<typename T> class X {
 // Test if complex multiply on this type works
 std::complex< X<double> > a, b, c;
 c = a * b;
+// Test if complex norm works
+c = std::norm(c);
 ],
  ac_cv_cxx_complex_templates=yes,
  ac_cv_cxx_complex_templates=no)


### PR DESCRIPTION
This is a small addition to the complex_templates configure check to verify that `std::norm()` works/compiles for user-defined types such as `std::complex<Estimate>`.